### PR TITLE
Convert ocp_cleanup.sh to destroy cluster

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -2,34 +2,9 @@
 
 set -e
 
-for server in $(openstack server list | grep rhcos \
-        | awk '{print $2}') ; do
-    openstack server delete $server
-done
+export OS_CLOUD="standalone"
+eval "$(go env)"
 
-for port in $(openstack port list \
-        | grep -E 'bootstrap|master' \
-        | awk '{print $2}') ; do
-    if [ "$port" != "|" ] ; then
-        openstack port delete $port
-    fi
-done
-
-for sg in $(openstack security group list | grep -E \
-        'master|worker|default|api|mcs|console' | awk '{print $2}') ; do
-    openstack security group delete $sg
-done
-
-ROUTER_ID=$(openstack router list | grep openshift-external-router | awk '{print $2}')
-
-for subnet in $(openstack subnet list | grep -E 'worker|masters' \
-        | awk '{print $2}') ; do
-    openstack router remove subnet ${ROUTER_ID} $subnet
-    openstack subnet delete $subnet
-done
-
-openstack router delete $ROUTER_ID
-
-openstack network delete openshift
+$GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster
 
 rm -rf ocp


### PR DESCRIPTION
Now that https://github.com/openshift/installer/pull/391 landed
we can replace the bash script with the cluster destroy command.

Note you will need to pull the latest openshift/installer then
re-run 05_build_ocp_installer.sh for this to work.