### PR TITLE
Update default RHCOS image to 47.188

### DIFF
--- a/get_rhcos_image.sh
+++ b/get_rhcos_image.sh
@@ -3,9 +3,9 @@ set -xe
 
 source common.sh
 
-RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.145}"
+RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.188}"
 RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
 RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 if [ ! -f "$RHCOS_IMAGE_FILENAME" ]; then
-    curl --insecure --compressed -L -O "https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}"
+    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
 fi


### PR DESCRIPTION
Recent images require the *.gz extension in their URL.