### PR TITLE
Rebase the `service-vm` branch instead of patches

### DIFF
--- a/04_ocp_repo_sync.sh
+++ b/04_ocp_repo_sync.sh
@@ -38,7 +38,6 @@ sync_go_repo_and_patch github.com/openshift/machine-config-operator https://gith
 sync_go_repo_and_patch \
   github.com/openshift/installer \
   https://github.com/openshift/installer.git \
-  https://github.com/tomassedovic/installer/commit/dns-workaround.patch \
   https://github.com/flaper87/installer/commit/service-vm.patch
 
 sync_go_repo_and_patch github.com/terraform-providers/terraform-provider-openstack https://github.com/terraform-providers/terraform-provider-openstack


### PR DESCRIPTION
Applying patches from the `service-vm` branch now fails because there's
more than one patch we need (and as far as I can tell, github doesn't
let us specify that).

So we could either curl and apply the individual commits (which means
updating ocp-doit every time we make a change to that branch) or just
checking the branch and merging it in.

This change does the latter approach as it's more future-proof.