### PR TITLE
Move image variables into common.sh

### DIFF
--- a/03_configure_undercloud.sh
+++ b/03_configure_undercloud.sh
@@ -28,9 +28,6 @@ if ! openstack image show cirros; then
     openstack image create cirros --container-format bare --disk-format qcow2 --public --file "$CIRROS_IMAGE_FILENAME"
 fi
 
-RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.145}"
-RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
-RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 ./get_rhcos_image.sh
 RHOS_IMAGE_HASH=$(sha512sum $RHCOS_IMAGE_FILENAME | awk '{print $1}')
 if ! openstack image show rhcos; then

--- a/common.sh
+++ b/common.sh
@@ -9,8 +9,11 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 source $CONFIG
-figlet $CONFIG | lolcat
-lolcat $CONFIG
+cat $CONFIG
 
 export REGISTRY=${REGISTRY:-$LOCAL_IP:8787}
 export REPO=${REPO:-$REGISTRY/openshift}
+
+export RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.188}"
+export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
+export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-openstack.qcow2"

--- a/get_rhcos_image.sh
+++ b/get_rhcos_image.sh
@@ -3,9 +3,6 @@ set -xe
 
 source common.sh
 
-RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.188}"
-RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
-RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 if [ ! -f "$RHCOS_IMAGE_FILENAME" ]; then
     curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
 fi


### PR DESCRIPTION
The recent version bump only updated get_rhcos_image.sh
so we'll calculate the image hash in 03_configure_undercloud.sh
with the old filename.

Probably best to move the variables to the common.sh, and I also
removed the lolcat/figlet usage as I need to run get_rhcos_image.sh
on a different box without all the dependencies installed, so lets
keep the requirements as minimal as possible.