### PR TITLE
Sync 06_run_ocp.sh with upstream CI

### DIFF
--- a/06_run_ocp.sh
+++ b/06_run_ocp.sh
@@ -5,4 +5,38 @@ set -e
 source ocp_install_env.sh
 source common.sh
 
+if [ ! -d ocp ]; then
+    mkdir -p ocp
+    export CLUSTER_ID=$(uuidgen --random)
+    cat > ocp/install-config.yml << EOF
+baseDomain: ${BASE_DOMAIN}
+clusterID:  ${CLUSTER_ID}
+machines:
+- name:     master
+  replicas: 3
+- name:     worker
+  replicas: 3
+metadata:
+  name: ${CLUSTER_NAME}
+networking:
+  clusterNetworks:
+  - cidr:             10.128.0.0/14
+    hostSubnetLength: 9
+  serviceCIDR: 172.30.0.0/16
+  type:        OpenshiftSDN
+platform:
+  openstack:
+    NetworkCIDRBlock: 10.0.0.0/16
+    baseImage:        ${OPENSTACK_IMAGE}
+    cloud:            ${OS_CLOUD}
+    externalNetwork:  ${OPENSTACK_EXTERNAL_NETWORK}
+    region:           ${OPENSTACK_REGION}
+pullSecret: |
+  ${PULL_SECRET}
+sshKey: |
+  ${SSH_PUB_KEY}
+EOF
+fi
+
+
 $GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug ${1:-create} ${2:-cluster} --dir ocp

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -1,28 +1,15 @@
 eval "$(go env)"
 
 export OS_CLOUD=openshift
-export OPENSHIFT_INSTALL_OPENSTACK_CLOUD="${OS_CLOUD}"
 export OPENSHIFT_INSTALL_DATA="$GOPATH/src/github.com/openshift/installer/data/data"
-export OPENSHIFT_INSTALL_OPENSTACK_REGION=regionOne
-export OPENSHIFT_INSTALL_OPENSTACK_IMAGE=rhcos
-export OPENSHIFT_INSTALL_BASE_DOMAIN=shiftstack.com
-export OPENSHIFT_INSTALL_CLUSTER_NAME=ostest
-export OPENSHIFT_INSTALL_EMAIL_ADDRESS=me@redhat.com
-export OPENSHIFT_INSTALL_PASSWORD=foobar
-export OPENSHIFT_INSTALL_PLATFORM=openstack
-export OPENSHIFT_INSTALL_OPENSTACK_EXTERNAL_NETWORK=public
-export OPENSHIFT_INSTALL_PULL_SECRET='{"auths": { "quay.io": { "auth": "Y29yZW9zK3RlYzJfaWZidWdsa2VndmF0aXJyemlqZGMybnJ5ZzpWRVM0SVA0TjdSTjNROUUwMFA1Rk9NMjdSQUZNM1lIRjRYSzQ2UlJBTTFZQVdZWTdLOUFIQlM1OVBQVjhEVlla", "email": "" }}}'
-export OPENSHIFT_INSTALL_SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
+export OPENSTACK_REGION=regionOne
+export OPENSTACK_IMAGE=rhcos
+export BASE_DOMAIN=shiftstack.com
+export CLUSTER_NAME=ostest
+export OPENSTACK_EXTERNAL_NETWORK=public
+export PULL_SECRET='{"auths": { "quay.io": { "auth": "Y29yZW9zK3RlYzJfaWZidWdsa2VndmF0aXJyemlqZGMybnJ5ZzpWRVM0SVA0TjdSTjNROUUwMFA1Rk9NMjdSQUZNM1lIRjRYSzQ2UlJBTTFZQVdZWTdLOUFIQlM1OVBQVjhEVlla", "email": "" }}}'
+export SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
 
 # Not used by the installer.  Used by s.sh.
-export OPENSHIFT_INSTALL_SSH_PRIV_KEY="$HOME/.ssh/id_rsa"
-
-# NOTE(trown): It seems like there is a bug with hardcoded path for the clouds.yaml file in manifests/tectonic.go
-# https://github.com/openshift/installer/blob/2b52ad20793d37471c5645cbbe089e8a6656b802/pkg/asset/manifests/tectonic.go#L23
-# We can workaround the bug by copying our clouds.yaml there
-# This will be fixed by https://github.com/openshift/installer/pull/588
-if ! [ -f /etc/openstack/clouds.yaml ]; then
-    sudo mkdir /etc/openstack
-    sudo cp $HOME/.config/openstack/clouds.yaml /etc/openstack/
-fi
+export SSH_PRIV_KEY="$HOME/.ssh/id_rsa"
 

--- a/s.sh
+++ b/s.sh
@@ -4,4 +4,4 @@ source ocp_install_env.sh
 
 NODE_ADDRESSES=`openstack server show ostest-$1 -f value -c addresses | cut -d',' -f1`
 NODE_IP=${NODE_ADDRESSES#"openshift="}
-sudo ip netns exec "qdhcp-$(openstack --os-cloud standalone network show openshift -f value -c id)" ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -i ${OPENSHIFT_INSTALL_SSH_PRIV_KEY} core@$NODE_IP
+sudo ip netns exec "qdhcp-$(openstack --os-cloud standalone network show openshift -f value -c id)" ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -i ${SSH_PRIV_KEY} core@$NODE_IP


### PR DESCRIPTION
The openshift/installer removed support for ENV vars, which makes
terraform prompt for the missing information. In upstream CI, where
answering prompts is not an option, they heredoc the install-config.yml
from the env vars.

This commit updates 06_run_ocp.sh to do the same. It also names the vars
the same as in the upstream CI repo.