### PR TITLE
Use `networking.machineCIDR`

### DIFF
--- a/06_run_ocp.sh
+++ b/06_run_ocp.sh
@@ -23,10 +23,10 @@ networking:
   - cidr:             10.128.0.0/14
     hostSubnetLength: 9
   serviceCIDR: 172.30.0.0/16
+  machineCIDR: 10.0.0.0/16
   type:        OpenshiftSDN
 platform:
   openstack:
-    NetworkCIDRBlock: 10.0.0.0/16
     baseImage:        ${OPENSTACK_IMAGE}
     cloud:            ${OS_CLOUD}
     externalNetwork:  ${OPENSTACK_EXTERNAL_NETWORK}


### PR DESCRIPTION
This pull request removed the platform-specific
`openstack.NetworkCIDRBlock` and friends in favour of a cross-platform
`networking.machineCIDR`:

https://github.com/openshift/installer/pull/983

Deployments using the old NetworkCIDRBlock are failing now.