### PR TITLE
Run DNS server in container at BM server

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -33,7 +33,8 @@ cd
 sudo tripleo-repos current-tripleo-dev
 sudo yum -y update
 sudo yum install -y python2-tripleoclient
-
+# make sure that 'dig' is installed
+sudo yum install -y bind-utils
 # TRIPLEO HEAT TEMPLATES
 if [ ! -d $SCRIPTDIR/tripleo-heat-templates ]; then
   cd $SCRIPTDIR

--- a/02_run_all_in_one.sh
+++ b/02_run_all_in_one.sh
@@ -2,9 +2,41 @@
 set -x
 
 source common.sh
-: ${DNS_SERVER_1:=1.1.1.1}
-: ${DNS_SERVER_2:=8.8.8.8}
 
+
+: ${DNS_SERVER_1:=1.1.1.1}
+
+# run CoreDns container (host-net), Neutron upstream-dns will point to this server and CoreDns will point to external DNS server
+sed -i "s/DNS_SERVER_1/$DNS_SERVER_1/g" coredns_cfg/Corefile
+sudo docker run -d  -m 128m --restart="unless-stopped" --net host --cap-add=NET_ADMIN -v "$PWD"/coredns_cfg:/etc/coredns   --name coredns coredns/coredns:latest -conf  /etc/coredns/Corefile
+
+
+function verify_dns {
+
+ips=($(dig  +short  -t srv _etcd-server-ssl._tcp.ostest.shiftstack.com. @"${LOCAL_IP}"))
+if [[ "$?" -eq 0 && "${#ips[@]}" -ne 0 ]]; then
+   echo "DNS resolve SRV record _etcd-server-ssl._tcp.ostest.shiftstack.com. -  Success"
+else
+   return 1
+fi
+
+ips=($(dig +short  google.com  @"${LOCAL_IP}"))
+echo $ips
+if [[ "$?" -eq 0 && "${#ips[@]}" -ne 0 ]]; then
+   echo "DNS resolve google.com - success"
+else
+   return 1
+fi
+   return 0
+}
+set +x
+if verify_dns; then
+  echo "Pre tripleo deployment - DNS is working!";
+else
+  echo -e "Pre tripleo deployment -DNS can not resolve SRV record, google.com\\nplease ***fix it*** (Docker service enabled? IPtables??)";
+  exit
+fi
+set -x
 openstack tripleo container image prepare default \
       --output-env-file $SCRIPTDIR/containers-prepare-parameters.yaml
 
@@ -19,11 +51,9 @@ parameter_defaults:
   Debug: true
   DeploymentUser: $USER
   DnsServers:
-    - $DNS_SERVER_1
-    - $DNS_SERVER_2
+    - $LOCAL_IP
   NeutronDhcpAgentDnsmasqDnsServers:
-    - $DNS_SERVER_1
-    - $DNS_SERVER_2
+    - $LOCAL_IP
   # needed for vip & pacemaker
   KernelIpNonLocalBind: 1
   DockerInsecureRegistryAddress:
@@ -64,3 +94,13 @@ sudo openstack tripleo deploy \
 sudo chown -R $USER:$USER ~/.config/openstack
 sed -i.bak 's/cloud:/#cloud:/' ~/.config/openstack/clouds.yaml
 sed -i.bak '4i\      domain_name: default' ~/.config/openstack/clouds.yaml
+
+# Enable DNS port and verify that DNS still working after tripleo deployment
+sudo iptables -I INPUT 2 -p udp --dport 53 -j ACCEPT
+sudo iptables -I INPUT 3 -p udp --sport 53 -j ACCEPT
+set +x
+if verify_dns; then
+  echo "Post tripleo deployment - DNS is working!";
+else
+  echo -e "Post tripleo deployment -DNS can not resolve SRV record, google.com (IPtables??)\\nplease ****Fix it**** before running next step!";
+fi

--- a/coredns_cfg/Corefile
+++ b/coredns_cfg/Corefile
@@ -1,0 +1,18 @@
+shiftstack.com {
+    log
+    errors
+    file /etc/coredns/db.shiftstack.com {
+        upstream DNS_SERVER_1
+        reload 10s
+    }
+}
+. {
+    log
+    errors
+    #auto
+    reload 10s
+    forward . DNS_SERVER_1 {
+        except shiftstack.com
+    }
+}
+

--- a/coredns_cfg/db.shiftstack.com
+++ b/coredns_cfg/db.shiftstack.com
@@ -1,0 +1,16 @@
+$ORIGIN shiftstack.com.
+@       3600 IN SOA sns.dns.icann.org. noc.dns.icann.org. (
+                                2017042745 ; serial
+                                7200       ; refresh (2 hours)
+                                3600       ; retry (1 hour)
+                                1209600    ; expire (2 weeks)
+                                3600       ; minimum (1 hour)
+                                )
+#ostest-master-0 IN A 10.0.0.223
+ostest-etcd-2.shiftstack.com.     IN   CNAME        ostest-master-2
+ostest-etcd-1.shiftstack.com.     IN   CNAME        ostest-master-1
+ostest-etcd-0.shiftstack.com.     IN   CNAME        ostest-master-0
+_etcd-server-ssl._tcp.ostest.shiftstack.com.  8640  IN      SRV         0     10 2380  ostest-etcd-0
+_etcd-server-ssl._tcp.ostest.shiftstack.com.  8640  IN      SRV         0     10 2380  ostest-etcd-1
+_etcd-server-ssl._tcp.ostest.shiftstack.com.  8640  IN      SRV         0     10 2380  ostest-etcd-2
+


### PR DESCRIPTION
For the DNS short term solution, the external DNS should be
configured with the relevant SRV and CNAME records.

In OCP-DOIT environment, we'll run a  DNS Server at the host that will
play the external DNS role.
The Neutron DNS will point to this server as the upstream server,
and the BM server will point to the LAB  external DNS server.