### PR TITLE
Add apiVersion to install-config.yaml we generate

### DIFF
--- a/06_run_ocp.sh
+++ b/06_run_ocp.sh
@@ -9,6 +9,7 @@ if [ ! -d ocp ]; then
     mkdir -p ocp
     export CLUSTER_ID=$(uuidgen --random)
     cat > ocp/install-config.yaml << EOF
+apiVersion: v1beta1
 baseDomain: ${BASE_DOMAIN}
 clusterID:  ${CLUSTER_ID}
 machines:


### PR DESCRIPTION
The installation will now fail without it. The `v1beta1` value is the
only accepted version right now.