### PR TITLE
Update the tripleo-heat-templates when 01* is run

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -36,8 +36,10 @@ sudo yum install -y python2-tripleoclient
 # make sure that 'dig' is installed
 sudo yum install -y bind-utils
 # TRIPLEO HEAT TEMPLATES
-if [ ! -d $SCRIPTDIR/tripleo-heat-templates ]; then
-  cd $SCRIPTDIR
-  cp -rv /usr/share/openstack-tripleo-heat-templates ./tripleo-heat-templates
+if [ -d $SCRIPTDIR/tripleo-heat-templates ]; then
+  rm -Rf $SCRIPTDIR/tripleo-heat-templates
 fi
+
+cd $SCRIPTDIR
+cp -rv /usr/share/openstack-tripleo-heat-templates ./tripleo-heat-templates
 


### PR DESCRIPTION
We're consumers of tripleo, not developers.

While having a local copy of THT is useful in case we need to apply unmerged patches, we shouldn't be treating it as part of the dev environment. Therefore, it should be fine to delete it and copy it again when 01 is run.