### PR TITLE
WIP Add scripts for setting up CI resources

### DIFF
--- a/ci-scripts/CI-DNS.yml
+++ b/ci-scripts/CI-DNS.yml
@@ -1,0 +1,148 @@
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1JnaVPFjGDuhzVUTNSug8TPqyCO14rsxSJ6fJiWJTj9LkqSoJ7SJy0NiLPWXygsnM6cvibpPZrDrmwqGHwTLlhnurbEUA8EvsddxOPkOzX+diMd6xthFMcdTYXS+sQQ9cPB6otrZai7GsAiT7OEQutF7g1JXIpzt1jBd8P+S3p5B5Av+AuDkSHwwvC8Y0IREQLBzitCQP9I9Mrw5KVS5uwVHajYri0s8ZvsXXJtxBUaWjRxFpyjvkL0NDPanfwdxQP3X0z2crY/RMr72dwjk0P74QQmfoD9juD3J8/9BkdWKLuhQTvTShduqhAJK9XXj2/pQj/IuM1ZSALVIW/Dgr
+storage:
+  files:
+    - path: /etc/coredns/dynamic-update.py
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          import SimpleHTTPServer
+          import SocketServer
+          import json
+     
+          # Edit these to suit your needs:
+          PORT = 8080
+          DOMAIN = "vexxhost.net"
+          COREDB_FILE = "/etc/coredns/db.{}".format(DOMAIN)
+     
+     
+          # You should probably not touch these unless you want to hardcode some records
+          COREDB_TEMPLATE = """
+          $ORIGIN {domain}.
+          @    3600 IN SOA host-10-0-0-2.{domain}. hostmaster (
+                                          {serial} ; serial
+                                          7200       ; refresh (2 hours)
+                                          3600       ; retry (1 hour)
+                                          1209600    ; expire (2 weeks)
+                                          3600       ; minimum (1 hour)
+                                          )
+     
+          {entries}
+          """
+          ENTRIES = {}
+          SERIAL_NUMBER = 0
+     
+     
+          def build_coredb_file(domain, serial_number, entries):
+              formatted_entries = '\n'.join("{} IN A {}".format(name, ip) for name, ip
+                  in entries.iteritems())
+              return COREDB_TEMPLATE.format(domain=domain, serial=serial_number,
+                  entries=formatted_entries)
+     
+     
+          class ServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+              def do_POST(self):
+                  global ENTRIES
+                  global SERIAL_NUMBER
+                  global DOMAIN
+                  content_len = int(self.headers.getheader('content-length', 0))
+                  post_body = self.rfile.read(content_len)
+                  body = ""
+                  try:
+                      body = json.loads(post_body)
+                  except Exception:
+                      self.send_response(422)
+                      print "Error, invalid JSON: {}".format(post_body)
+                      return
+                  self.send_response(200)
+                  if 'name' in body and 'ip' in body:
+                      ENTRIES[body['name']] = body['ip']
+                      SERIAL_NUMBER += 1
+                      db = build_coredb_file(DOMAIN, SERIAL_NUMBER, ENTRIES)
+                      print "Writing version {} to file {}".format(SERIAL_NUMBER, COREDB_FILE)
+                      with open(COREDB_FILE, 'w') as f:
+                          f.write(db)
+                  else:
+                      print "Invalid format of body", repr(body)
+     
+     
+          if __name__ == '__main__':
+              Handler = ServerHandler
+              httpd = SocketServer.TCPServer(("", PORT), Handler)
+              print "serving at port", PORT
+              httpd.serve_forever()
+
+    - path: /etc/coredns/Corefile
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          . {
+              log
+              errors
+              reload 10s
+
+              file /etc/coredns/db.vexxhost.net trown-ef260-api.vexxhost.net {
+              }
+
+              forward . 8.8.8.8 {
+                  except trown-ef260.vexxhost.net
+              }
+          }
+
+          trown-ef260.vexxhost.net {
+              log
+              errors
+              reload 10s
+
+              file /etc/coredns/db.vexxhost.net {
+              }
+          }
+
+    - path: /etc/coredns/db.vexxhost.net
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          $ORIGIN vexxhost.net.
+          @    3600 IN SOA host-trown-ef260.vexxhost.net. hostmaster (
+                                          2017042752 ; serial
+                                          7200       ; refresh (2 hours)
+                                          3600       ; retry (1 hour)
+                                          1209600    ; expire (2 weeks)
+                                          3600       ; minimum (1 hour)
+                                          )
+
+
+systemd:
+  units:
+    - name: ci-dns.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CI DNS
+
+        [Service]
+        ExecStart=/bin/podman run --rm -i -t -m 128m --net host --cap-add=NET_ADMIN -v /etc/coredns:/etc/coredns:Z openshift/origin-coredns:v4.0 -conf /etc/coredns/Corefile
+        Restart=always
+        RestartSec=10
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: dynamic-dns-updater.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Dynamic DNS updater
+
+        [Service]
+        ExecStart=/bin/python /etc/coredns/dynamic-update.py
+        Restart=always
+        RestartSec=10
+
+        [Install]
+        WantedBy=multi-user.target

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -1,0 +1,16 @@
+Scripts needed to bring up CI tenant
+====================================
+
+# Build Ignition File
+`/home/jtrowbri/src/coreos/container-linux-config-transpiler/bin/ct --in-file CI-DNS.yml > CI-DNS.ign`
+
+# Boot DNS VM
+`openstack server create --user-data ./CI-DNS.ign --image b9f17972-1c3c-417f-8f08-15aa31c43a32 --flavor v1-standard-1 --security-group default --security-group CI-DNS --config-drive=true --nic net-id=4e1bce4c-193b-42ea-a494-ab05aff89c1d CI-DNS`
+
+# Assign Floating IP hardcoded in CI template as DNS server
+`openstack server add floating ip CI-DNS 162.253.55.43`
+
+# Run CI
+`home/jtrowbri/go/src/github.com/openshift/ci-operator/ci-operator -template templates/cluster-launch-installer-e2e-modified.yaml -config ~/src/openshift/release/ci-operator/config/openshift/installer/openshift-installer-master.yaml -git-ref=openshift/installer@master -secret-dir=/home/jtrowbri/src/openshift/installer-e2e/cluster-profile-openstack -namespace=trown --target=cluster-launch-installer-e2e-modified`
+
+


### PR DESCRIPTION
We need a DNS server in our CI tenant that can have entries dynamically
added when a new job starts.

This commit adds an ignition config to create such a server using the
CoreOS image with coredns. This sets up coredns to watch for changes to
the local filesystem, as well as a simple python HTTP server that can
update the entries dynamically.

With this server running and some minor hacks on the CI job[1], I am
able to get to a fully automated e2e deploy on vexxhost.

[1] https://github.com/trown/installer-e2e/commit/c2a8b66122366c5bcb5b77d226b4a2999a57a457