### PR TITLE
Update api URL for installer/PR1169

### DIFF
--- a/expose_ocp_api.sh
+++ b/expose_ocp_api.sh
@@ -15,5 +15,5 @@ LB_FLOATING_IP=$(openstack server show ostest-api -f value -c addresses | cut -d
 echo "Attempting to expose cluster's API on floating IP: ${LB_FLOATING_IP}" | lolcat
 
 if ! grep -q ${LB_FLOATING_IP} /etc/hosts ; then
-    (echo "${LB_FLOATING_IP} ostest-api.shiftstack.com" && grep -v "ostest-api.shiftstack.com" /etc/hosts) | sudo tee /etc/hosts
+    (echo "${LB_FLOATING_IP} api.ostest.shiftstack.com" && grep -v "api.ostest.shiftstack.com" /etc/hosts) | sudo tee /etc/hosts
 fi

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -11,7 +11,7 @@ export OPENSTACK_EXTERNAL_NETWORK=public
 export PULL_SECRET='{"auths": { "quay.io": { "auth": "Y29yZW9zK3RlYzJfaWZidWdsa2VndmF0aXJyemlqZGMybnJ5ZzpWRVM0SVA0TjdSTjNROUUwMFA1Rk9NMjdSQUZNM1lIRjRYSzQ2UlJBTTFZQVdZWTdLOUFIQlM1OVBQVjhEVlla", "email": "" }}}'
 export SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
 
-export API_ADRESS="ostest-api.shiftstack.com"
+export API_ADRESS="api.ostest.shiftstack.com"
 export CONSOLE_ADRESS="console-openshift-console.apps.shiftstack.com"
 
 # Not used by the installer.  Used by s.sh.


### PR DESCRIPTION
https://github.com/openshift/installer/pull/1169 changes the URL for
the api. Once that merges, we will need this patch to update the
script that exposes the api.