### PR TITLE
Fix recreation of install-config.yaml

### DIFF
--- a/06_run_ocp.sh
+++ b/06_run_ocp.sh
@@ -7,6 +7,9 @@ source common.sh
 
 if [ ! -d ocp ]; then
     mkdir -p ocp
+fi
+
+if [ ! -f ocp/install-config.yaml ]; then
     export CLUSTER_ID=$(uuidgen --random)
     cat > ocp/install-config.yaml << EOF
 apiVersion: v1beta1


### PR DESCRIPTION
Currently 06_run_ocp.sh creates install-config.yaml only if
ocp folder is missing. But when the installer is started, the
file is removed from the system. It leads to the fact that on
the second attempt of deploying OCP install-config.yaml is not
generated and the deployment fails immediately.

This commit adds a check that the file exists, and generates it
again in case of its absense.