### PR TITLE
Enable package installation for TripleO

### DIFF
--- a/02_run_all_in_one.sh
+++ b/02_run_all_in_one.sh
@@ -23,6 +23,7 @@ parameter_defaults:
   DeploymentUser: $USER
   DnsServers:
     - $LOCAL_IP
+  EnablePackageInstall: true
   NeutronDhcpAgentDnsmasqDnsServers:
     - $LOCAL_IP
   # needed for vip & pacemaker


### PR DESCRIPTION
Now on the CentOS system with minimal installation there is
no "ntpdate" package, which leads to a failure when we want
to synchronize time on the second step:
https://github.com/openstack/tripleo-heat-templates/blob/master/deployment/time/ntp-baremetal-puppet.yaml#L114

TripleO is able to install the package during the deployment, but
the flag EnablePackageInstall should be set to "true" in that case.