### PR TITLE
Automatically create a floating IP for OCP

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -6,4 +6,8 @@ source ocp_install_env.sh
 
 $GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster
 
+# clean /etc/hosts
+grep -qxF "$API_ADRESS" /etc/hosts || sudo sed -i "/$API_ADRESS/d" /etc/hosts
+grep -qxF "$CONSOLE_ADRESS" /etc/hosts || sudo sed -i "/$CONSOLE_ADRESS/d" /etc/hosts
+
 rm -rf ocp/{auth,terraform.tfstate}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -11,6 +11,9 @@ export OPENSTACK_EXTERNAL_NETWORK=public
 export PULL_SECRET='{"auths": { "quay.io": { "auth": "Y29yZW9zK3RlYzJfaWZidWdsa2VndmF0aXJyemlqZGMybnJ5ZzpWRVM0SVA0TjdSTjNROUUwMFA1Rk9NMjdSQUZNM1lIRjRYSzQ2UlJBTTFZQVdZWTdLOUFIQlM1OVBQVjhEVlla", "email": "" }}}'
 export SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
 
+export API_ADRESS="ostest-api.shiftstack.com"
+export CONSOLE_ADRESS="console-openshift-console.apps.shiftstack.com"
+
 # Not used by the installer.  Used by s.sh.
 export SSH_PRIV_KEY="$HOME/.ssh/id_rsa"
 


### PR DESCRIPTION
Now to deploy OpenShift we have to manually create and assign a floating IP address for the load balancer.

This commit automates this process: it creates a new floating ip, if necessary, and adds it to /etc/hosts and install-config.yaml