### PR TITLE
Bump install config API version

### DIFF
--- a/06_run_ocp.sh
+++ b/06_run_ocp.sh
@@ -26,7 +26,7 @@ fi
 if [ ! -f ocp/install-config.yaml ]; then
     export CLUSTER_ID=$(uuidgen --random)
     cat > ocp/install-config.yaml << EOF
-apiVersion: v1beta1
+apiVersion: v1beta3
 baseDomain: ${BASE_DOMAIN}
 clusterID:  ${CLUSTER_ID}
 machines:


### PR DESCRIPTION
Currently if we use v1beta1 we have next message:

FATAL failed to fetch Terraform Variables: failed to load asset
"Install Config": invalid "install-config.yaml" file: apiVersion:
Invalid value: "v1beta1": install-config version must be "v1beta3"

To fix this we have to change the version to v1beta3