### PR TITLE
Add auth url to /etc/hosts

### DIFF
--- a/06_run_ocp.sh
+++ b/06_run_ocp.sh
@@ -16,8 +16,9 @@ if [ -z "$FLOATING_IP" ]; then
 fi
 
 # add data to /etc/hosts
-grep -qxF "$FLOATING_IP $API_ADRESS" /etc/hosts || echo "$FLOATING_IP $API_ADRESS" | sudo tee -a /etc/hosts
-grep -qxF "$FLOATING_IP $CONSOLE_ADRESS" /etc/hosts || echo "$FLOATING_IP $CONSOLE_ADRESS" | sudo tee -a /etc/hosts
+grep -qxF "$FLOATING_IP $API_ADDRESS" /etc/hosts || echo "$FLOATING_IP $API_ADDRESS" | sudo tee -a /etc/hosts
+grep -qxF "$FLOATING_IP $CONSOLE_ADDRESS" /etc/hosts || echo "$FLOATING_IP $CONSOLE_ADDRESS" | sudo tee -a /etc/hosts
+grep -qxF "$FLOATING_IP $AUTH_ADDRESS" /etc/hosts || echo "$FLOATING_IP $AUTH_ADDRESS" | sudo tee -a /etc/hosts
 
 if [ ! -d ocp ]; then
     mkdir -p ocp

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -7,7 +7,8 @@ source ocp_install_env.sh
 $GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster
 
 # clean /etc/hosts
-grep -qxF "$API_ADRESS" /etc/hosts || sudo sed -i "/$API_ADRESS/d" /etc/hosts
-grep -qxF "$CONSOLE_ADRESS" /etc/hosts || sudo sed -i "/$CONSOLE_ADRESS/d" /etc/hosts
+grep -qxF "$API_ADDRESS" /etc/hosts || sudo sed -i "/$API_ADDRESS/d" /etc/hosts
+grep -qxF "$CONSOLE_ADDRESS" /etc/hosts || sudo sed -i "/$CONSOLE_ADDRESS/d" /etc/hosts
+grep -qxF "$AUTH_ADDRESS" /etc/hosts || sudo sed -i "/$AUTH_ADDRESS/d" /etc/hosts
 
 rm -rf ocp/{auth,terraform.tfstate}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -11,8 +11,9 @@ export OPENSTACK_EXTERNAL_NETWORK=public
 export PULL_SECRET='{"auths": { "quay.io": { "auth": "Y29yZW9zK3RlYzJfaWZidWdsa2VndmF0aXJyemlqZGMybnJ5ZzpWRVM0SVA0TjdSTjNROUUwMFA1Rk9NMjdSQUZNM1lIRjRYSzQ2UlJBTTFZQVdZWTdLOUFIQlM1OVBQVjhEVlla", "email": "" }}}'
 export SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
 
-export API_ADRESS="api.${CLUSTER_NAME}.shiftstack.com"
-export CONSOLE_ADRESS="console-openshift-console.apps.shiftstack.com"
+export API_ADDRESS="api.${CLUSTER_NAME}.shiftstack.com"
+export CONSOLE_ADDRESS="console-openshift-console.apps.shiftstack.com"
+export AUTH_ADDRESS="openshift-authentication-openshift-authentication.apps.ostest.shiftstack.com"
 
 # Not used by the installer.  Used by s.sh.
 export SSH_PRIV_KEY="$HOME/.ssh/id_rsa"


### PR DESCRIPTION
This commit adds a new entry to /etc/hosts to specify OpenShift's auth url.

Without it we get a error like
error: dial tcp: lookup openshift-authentication-openshift-authentication.apps.ostest.shiftstack.com on 10.1.8.84:53: read udp 10.1.8.84:34665->10.1.8.84:53: read: connection refused
when we try to authenticate