### PR TITLE
Do not download amphora image if present

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -56,8 +56,10 @@ cd $SCRIPTDIR
 cp -rv /usr/share/openstack-tripleo-heat-templates ./tripleo-heat-templates
 
 # Download amphora image for octavia:
-sudo mkdir /usr/share/openstack-octavia-amphora-images/
-sudo curl -o /usr/share/openstack-octavia-amphora-images/amphora-x64-haproxy.qcow2 http://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
+sudo mkdir -p /usr/share/openstack-octavia-amphora-images/
+if [ ! -f /usr/share/openstack-octavia-amphora-images/amphora-x64-haproxy.qcow2 ]; then
+  sudo curl -o /usr/share/openstack-octavia-amphora-images/amphora-x64-haproxy.qcow2 http://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
+fi
 
 # Set hostname properly.
 HOSTNAME=`host $LOCAL_IP | cut -f 5 -d ' ' | sed s/.$//`

--- a/03_configure_undercloud.sh
+++ b/03_configure_undercloud.sh
@@ -46,14 +46,8 @@ elif ! openstack image show rhcos -c properties -f shell | grep -q $RHOS_IMAGE_H
 fi
 
 # Set up all the stuff we need for octavia.
-OCTAVIA_AMPHORA="amphora-x64-haproxy-centos.qcow2"
-echo $OCTAVIA_AMPHORA | figlet | lolcat
-
 if ! openstack image show amphora-image; then
-    if [ ! -f "$OCTAVIA_AMPHORA" ]; then
-        curl -o $OCTAVIA_AMPHORA https://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
-    fi
-    openstack image create --container-format bare --disk-format qcow2 --public --tag amphora-image --file $OCTAVIA_AMPHORA amphora-image
+    openstack image create --container-format bare --disk-format qcow2 --public --tag amphora-image --file /usr/share/openstack-octavia-amphora-images/amphora-x64-haproxy.qcow2 amphora-image
 fi
 
 HOST_LOCALDOMAIN=`hostname -A | sed 's/ /\n/g' | grep localdomain`


### PR DESCRIPTION
Unless the amphora image is being updated regularly and we need to get
a fresh copy often, there's no need to download it each time we're
running the 01_install_requirements.sh script.