### PR TITLE
Use CLUSTER_NAME in use-custom-CAPO.sh

### DIFF
--- a/use-custom-CAPO.sh
+++ b/use-custom-CAPO.sh
@@ -1,4 +1,8 @@
-: ${KUBECONFIG:=ocp/auth/kubeconfig}
+#!/bin/bash
+
+source ocp_install_env.sh
+
+: ${KUBECONFIG:=$CLUSTER_NAME/auth/kubeconfig}
 : ${OLD_IMAGE:=docker.io/openshift/origin-openstack-machine-controllers:v4.0.0}
 : ${NEW_IMAGE:=quay.io/trown/openstack-machine-controllers:rebase}
 


### PR DESCRIPTION
Currently kubeconfig is placed in a folder named after the cluster, "ostest" by default.

This commit changes the hardcoded "ocp" folder to the cluster name to search kubeconfig in.